### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/audio_in_nixos.org
+++ b/audio_in_nixos.org
@@ -13,9 +13,9 @@ https://github.com/magnetophon/nixosConfig/
   some top-level .nix files from which I have emulated
 https://github.com/musnix/musnix
   Not sure what it gets me.
-https://nixos.wiki/wiki/JACK
+https://wiki.nixos.org/wiki/JACK
   The first part is not obsolete, right?
-https://nixos.wiki/wiki/Audio
+https://wiki.nixos.org/wiki/Audio
   pretty weak -- ALSA section is out of date, doesn't link to JACK section
 ** TODO promising places I've spoken
 https://github.com/musnix/musnix/issues/100

--- a/cheese.org
+++ b/cheese.org
@@ -18,7 +18,7 @@ apply the first diff in the branch called
     pulseaudio # I'm just guessing I need this; nobody said so
 **** audio.nix: I added these lines
     # For feeding the mic into Cheese (for webcam videos)
-    # Was suggested here: https://nixos.wiki/wiki/PulseAudio
+    # Was suggested here: https://wiki.nixos.org/wiki/PulseAudio
     # PITFALL: This borks much of my audio setup.
     hardware.pulseaudio.enable = true;
 * use lsof to check what processes (esp. pulseaudio, alsamixer) are using sound devices
@@ -28,6 +28,6 @@ sudo lsof /dev/snd/*
 to connect mic to Cheese
 https://www.youtube.com/watch?v=M0B0-SilJw4
 ** Pulse Audio on NixOS wiki
-https://nixos.wiki/wiki/PulseAudio
+https://wiki.nixos.org/wiki/PulseAudio
 ** Pulse Audio on Arch wiki
 https://wiki.archlinux.org/index.php/PulseAudio

--- a/django_in_aws_esp_aws_eb.org
+++ b/django_in_aws_esp_aws_eb.org
@@ -9,7 +9,7 @@
 * WART: sidestepping the Python, virtualenv, NixOS headache
   AWS suggests using a virtualenv to install Django from pip.
   Python and virtualenv are confusing on NixOS:
-    https://nixos.wiki/wiki/Python
+    https://wiki.nixos.org/wiki/Python
   So I'm just using Docker -- specifically tax.co.
 * once, run `django-admin startproject ebdjango`
   Like `stack new`, this writes a new project (filetree)

--- a/nixos_packages_create_build_install_publish.org
+++ b/nixos_packages_create_build_install_publish.org
@@ -4,7 +4,7 @@
 #+title: NixOS packages: find, create, build, install, uninstall, publish
 * refs
 ** u
-   https://nixos.wiki/wiki/Nixpkgs/Create_and_debug_packages
+   https://wiki.nixos.org/wiki/Nixpkgs/Create_and_debug_packages
    https://nixos.org/nixos/manual/index.html#sec-custom-packages
 ** NixOS manual / quick start to adding a package
    https://nixos.org/manual/nixpkgs/stable/#chap-quick-start

--- a/python_and_virtualenv_in_nix.org
+++ b/python_and_virtualenv_in_nix.org
@@ -20,7 +20,7 @@ https://wiki.nixos.org/wiki/Python
    deactivate
 * stale
 ** old wiki
-   https://nixos.wiki/wiki/Python
+   https://wiki.nixos.org/wiki/Python
 ** used to be my favorite way to use Python in NixOS: use both nix and virtualenv
 *** why it's my favorite way
     Going fully Nix went badly for me,


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️